### PR TITLE
Create inheritable base schema with default expand method and client formatter; Add catalog field to Work and Composer

### DIFF
--- a/src/api/routes/composer.js
+++ b/src/api/routes/composer.js
@@ -1,43 +1,8 @@
 const route = require('express-promise-router')()
+const { PostSchema, PatchSchema } = require('../schemas/composer')
 const ComposerService = require('../../services/composer')
 const { NotFoundError } = require('../middleware/errors')
 const { bodyValidator } = require('../middleware/validation')
-
-// req is a bool that turns required fields on or off; used to generate a POST or PATCH schema
-const ComposerSchema = req => {
-  return {
-    type: 'object',
-    properties: {
-      name: {
-        type: 'object',
-        properties: {
-          title: {type: 'string'},
-          first: {type: 'string'},
-          last: {type: 'string'},
-          middle: {type: 'string'},
-          suffix: {type: 'string'},
-          nick: {type: 'string'}
-        },
-        required: req ? ['first', 'last'] : undefined,
-        additionalProperties: false
-      },
-      info: {
-        type: 'object',
-        properties: {
-          content: {type: 'string'}
-        },
-        required: ['content'],
-        additionalProperties: false
-      },
-      catalog: {type: 'string'},
-    },
-    required: req ? ['name', 'info'] : undefined,
-    additionalProperties: false
-  }
-}
-
-const PostSchema = ComposerSchema(true)
-const PatchSchema = ComposerSchema(false)
 
 module.exports = (router) => {
   router.use('/composer', route)

--- a/src/api/routes/composer.js
+++ b/src/api/routes/composer.js
@@ -20,9 +20,18 @@ const ComposerSchema = req => {
         },
         required: req ? ['first', 'last'] : undefined,
         additionalProperties: false
-      }
+      },
+      info: {
+        type: 'object',
+        properties: {
+          content: {type: 'string'}
+        },
+        required: ['content'],
+        additionalProperties: false
+      },
+      catalog: {type: 'string'},
     },
-    required: req ? ['name'] : undefined,
+    required: req ? ['name', 'info'] : undefined,
     additionalProperties: false
   }
 }

--- a/src/api/routes/work.js
+++ b/src/api/routes/work.js
@@ -1,51 +1,8 @@
 const route = require('express-promise-router')()
+const { PostSchema, PatchSchema } = require('../schemas/work')
 const WorkService = require('../../services/work')
 const { NotFoundError } = require('../middleware/errors')
 const { bodyValidator } = require('../middleware/validation')
-
-// req is a bool that turns required fields on or off; used to generate a POST or PATCH schema
-const WorkSchema = req => {
-  return {
-    type: 'object',
-    properties: {
-      name: {type: 'string'},
-      composer: {type: 'string'},
-      movements: {
-        type: 'array',
-        items: {
-          type: 'object',
-          properties: {
-            order: {type: 'integer'},
-            name: {type: 'string'}
-          },
-          required: ['order', 'name'],
-          additionalProperties: false
-        }
-      },
-      catalog: {
-        type: 'object',
-        properties: {
-          name: {type: 'string'},
-          no: {type: 'string'}
-        },
-        additionalProperties: false
-      },
-      info: { // TODO: redesign InfoSchema
-        type: 'object',
-        properties: {
-          content: {type: 'string'}
-        },
-        required: ['content'],
-        additionalProperties: false
-      }
-    },
-    required: req ? ['name', 'composer', 'info'] : undefined,
-    additionalProperties: false
-  }
-}
-
-const PostSchema = WorkSchema(true)
-const PatchSchema = WorkSchema(false)
 
 module.exports = (router) => {
   router.use('/work', route)

--- a/src/api/routes/work.js
+++ b/src/api/routes/work.js
@@ -22,8 +22,14 @@ const WorkSchema = req => {
           additionalProperties: false
         }
       },
-      catalog: {type: 'string'},
-      catalogNo: {type: 'string'},
+      catalog: {
+        type: 'object',
+        properties: {
+          name: {type: 'string'},
+          no: {type: 'string'}
+        },
+        additionalProperties: false
+      },
       info: { // TODO: redesign InfoSchema
         type: 'object',
         properties: {

--- a/src/api/schemas/composer.js
+++ b/src/api/schemas/composer.js
@@ -1,0 +1,32 @@
+const InfoSchema = require('./info')
+
+// req is a bool that turns required fields on or off; used to generate a POST or PATCH schema
+const ComposerSchema = req => {
+  return {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'object',
+        properties: {
+          title: {type: 'string'},
+          first: {type: 'string'},
+          last: {type: 'string'},
+          middle: {type: 'string'},
+          suffix: {type: 'string'},
+          nick: {type: 'string'}
+        },
+        required: req ? ['first', 'last'] : undefined,
+        additionalProperties: false
+      },
+      info: InfoSchema,
+      catalog: {type: 'string'},
+    },
+    required: req ? ['name', 'info'] : undefined,
+    additionalProperties: false
+  }
+}
+
+const PostSchema = ComposerSchema(true)
+const PatchSchema = ComposerSchema(false)
+
+module.exports = { ComposerSchema, PostSchema, PatchSchema }

--- a/src/api/schemas/info.js
+++ b/src/api/schemas/info.js
@@ -1,0 +1,10 @@
+const InfoSchema = {
+  type: 'object',
+  properties: {
+    content: {type: 'string'}
+  },
+  required: ['content'],
+  additionalProperties: false
+}
+
+module.exports = InfoSchema

--- a/src/api/schemas/movement.js
+++ b/src/api/schemas/movement.js
@@ -1,0 +1,11 @@
+const MovementSchema = {
+  type: 'object',
+  properties: {
+    order: {type: 'integer'},
+    name: {type: 'string'}
+  },
+  required: ['order', 'name'],
+  additionalProperties: false
+}
+
+module.exports = MovementSchema

--- a/src/api/schemas/work.js
+++ b/src/api/schemas/work.js
@@ -1,0 +1,33 @@
+const InfoSchema = require('./info')
+const MovementSchema = require('./movement')
+
+// req is a bool that turns required fields on or off; used to generate a POST or PATCH schema
+const WorkSchema = req => {
+  return {
+    type: 'object',
+    properties: {
+      name: {type: 'string'},
+      composer: {type: 'string'},
+      movements: {
+        type: 'array',
+        items: MovementSchema
+      },
+      catalog: {
+        type: 'object',
+        properties: {
+          name: {type: 'string'},
+          no: {type: 'string'}
+        },
+        additionalProperties: false
+      },
+      info: InfoSchema
+    },
+    required: req ? ['name', 'composer', 'info'] : undefined,
+    additionalProperties: false
+  }
+}
+
+const PostSchema = WorkSchema(true)
+const PatchSchema = WorkSchema(false)
+
+module.exports = { WorkSchema, PostSchema, PatchSchema }

--- a/src/models/composer.js
+++ b/src/models/composer.js
@@ -1,13 +1,10 @@
 const mongoose = require('mongoose')
-const { Schema } = mongoose
 const { InfoSchema } = require('./info')
-const { generateId, List } = require('./')
+const { ExpandableSchema } = require('./')
 
-const ComposerSchema = new Schema({
-  _id: {
-    type: String,
-    default: generateId
-  },
+const MODEL_NAME = 'composer'
+
+const ComposerSchema = ExpandableSchema(MODEL_NAME, {
   name: {
     title: String,
     first: {type: String, required: true},
@@ -18,74 +15,14 @@ const ComposerSchema = new Schema({
   },
   info: InfoSchema,
   catalog: String
-})
-
-ComposerSchema.virtual('works', {
-  ref: 'work',
-  localField: '_id',
-  foreignField: 'composer',
-});
-
-// TODO: only supports first-level expansions; should support nested expansion
-// TODO: cleanup expand algorithm
-const EXPANDABLE_DOCS = []
-const EXPANDABLE_ARRAYS = ['works']
-const POPULATE_LIMIT = 10
-
-ComposerSchema.method('expand', async function(props) {
-  let query = this
-
-  // TODO: protect against duplicate props
-
-  props.forEach(prop => {
-    const isDoc = EXPANDABLE_DOCS.includes(prop)
-    const isArray = EXPANDABLE_ARRAYS.includes(prop)
-
-    if (!isDoc && !isArray) throw new Error(`Unable to expand property ${prop} in composer.`) // TODO: throw error catchable by API route to throw a 400
-    
-    if (isArray) {
-      query.populate({path: prop, options: {limit: POPULATE_LIMIT}})
-    } else {
-      query = query.populate(prop)
-    }
-  })
-
-  let result = await query.execPopulate()
-
-  props.forEach(prop => {
-    if (EXPANDABLE_ARRAYS.includes(prop)) {
-      result.$locals[prop] = {hasMore: result[prop].length >= POPULATE_LIMIT}
-    }
-  })
-
-  return result
-})
-
-// TODO: generalize using EXPANDABLE_PROPS
-ComposerSchema.method('toClient', function() {
-  let obj = this.toObject()
-
-  const id = obj._id
-  const object = 'composer'
-
-  if (obj.info) obj.info = this.info.toClient()
-  if (this.works) {
-    const data = this.works.map(w => w.toClient())
-    const list = new List(data, this.$locals.works.hasMore, '/') // TODO: use real url
-
-    obj.works = list.toClient()
+}, {
+  works: {
+    ref: 'work',
+    localField: '_id',
+    foreignField: 'composer',
   }
-
-  const prune = ({name, info, catalog, works}) => ({id, object, name, info, catalog, works})
-  obj = prune(obj)
-
-  if (this.$locals.deleted) {
-    obj.deleted = true
-  }
-
-  return obj
 })
 
-const Composer = mongoose.model('composer', ComposerSchema)
+const Composer = mongoose.model(MODEL_NAME, ComposerSchema)
 
 module.exports = {Composer, ComposerSchema}

--- a/src/models/composer.js
+++ b/src/models/composer.js
@@ -16,7 +16,8 @@ const ComposerSchema = new Schema({
     suffix: String,
     nick: String
   },
-  info: InfoSchema
+  info: InfoSchema,
+  catalog: String
 })
 
 ComposerSchema.method('toClient', function() {
@@ -25,7 +26,9 @@ ComposerSchema.method('toClient', function() {
   const id = obj._id
   const object = 'composer'
 
-  const prune = ({name, info}) => ({id, object, name, info})
+  if (obj.info) obj.info = this.info.toClient()
+
+  const prune = ({name, info, catalog}) => ({id, object, name, info, catalog})
   obj = prune(obj)
 
   if (this.$locals.deleted) {

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -126,6 +126,10 @@ const addClientFormatter = (name, schema, def, virtuals) => {
       newObj[prop] = this[prop].toClient()
     })
   
+    if (this.$locals.deleted) {
+      newObj.deleted = true
+    }
+
     return newObj
   })
 }

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,6 +1,134 @@
+const Schema = require('mongoose').Schema
 const { customAlphabet, urlAlphabet } = require('nanoid')
 
 const generateId = customAlphabet(urlAlphabet, 10)
+
+const EXPAND_LIMIT = 10 // populate limit on arrays
+
+const ExpandableSchema = function(name, def = {}, virtuals = {}, options) {
+  const schema = new Schema({
+    _id: {
+      type: String,
+      default: generateId
+    },
+    ...def
+  }, options)
+
+  // add virtual props to schema
+  for (prop in virtuals) {
+    schema.virtual(prop, virtuals[prop])
+  }
+
+  addExpand(name, schema)
+  addClientFormatter(name, schema, def, virtuals)
+
+  return schema
+}
+
+// gets populateable real and virtual props
+const getExpandableProps = schema => {
+  const expandableArrays = []
+  const expandableDocs = []
+
+  Object.values(schema.paths).forEach(path => {
+    if (path.options.ref) {
+      if (path instanceof Schema.Types.String) expandableDocs.push(path.path)
+    }
+  })
+
+  Object.values(schema.virtuals).forEach(path => {
+    if (path.options.ref) {
+      expandableArrays.push(path.path)
+    }
+  })
+
+  return {expandableArrays, expandableDocs}
+}
+
+const getSubDocProps = schema => {
+  const {expandableArrays, expandableDocs} = getExpandableProps(schema)
+
+  const subDocArrays = [...expandableArrays]
+  const subDocs = [...expandableDocs]
+
+  Object.values(schema.paths).forEach(path => {
+    if (path instanceof Schema.Types.Embedded) subDocs.push(path.path)
+    if (path instanceof Schema.Types.DocumentArray) subDocArrays.push(path.path)
+  })
+
+  return {subDocArrays, subDocs}
+}
+
+const addExpand = (name, schema) => {
+  const {expandableArrays, expandableDocs} = getExpandableProps(schema)
+
+  schema.method('expand', async function(props) {
+    let query = this
+  
+    // TODO: protect against duplicate props
+  
+    props.forEach(prop => {
+      const isDoc = expandableDocs.includes(prop)
+      const isArray = expandableArrays.includes(prop)
+  
+      if (!isDoc && !isArray) throw new Error(`Unable to expand property ${prop} in ${name}.`) // TODO: throw error catchable by API route to throw a 400
+      
+      if (isArray) {
+        query.populate({path: prop, options: {limit: EXPAND_LIMIT}})
+      } else {
+        query = query.populate(prop)
+      }
+    })
+  
+    const result = await query.execPopulate()
+  
+    props.forEach(prop => {
+      if (expandableArrays.includes(prop)) {
+        result.$locals[prop] = {hasMore: result[prop].length >= EXPAND_LIMIT} // TODO: invalid way of checking if more docs exist
+      }
+    })
+  
+    return result
+  })
+}
+
+const addClientFormatter = (name, schema, def, virtuals) => {
+  const clientProps = Object.keys(def).concat(Object.keys(virtuals)) // props to return in client response
+  const {subDocs, subDocArrays} = getSubDocProps(schema)
+  const {expandableDocs, expandableArrays} = getExpandableProps(schema)
+
+  schema.method('toClient', function() {
+    let obj = this.toObject()
+  
+    const id = obj._id
+    const object = name
+
+    const newObj = clientProps.reduce((newObj, prop) => {
+      return Object.assign(newObj, {[prop]: obj[prop]})
+    }, {id, object})
+
+    subDocArrays.forEach(prop => {
+      if (!this[prop]) return
+
+      const data = this[prop].map(doc => doc.toClient())
+
+      if (this.populated(prop)) {
+        const list = new List(data, this.$locals[prop].hasMore, '/') // TODO: use real url
+        newObj[prop] = list.toClient()
+      } else {
+        newObj[prop] = data
+      }
+    })
+
+    subDocs.forEach(prop => {
+      if (!this[prop] || !this[prop].toClient) return
+
+      newObj[prop] = this[prop].toClient()
+    })
+  
+    return newObj
+  })
+}
 
 const List = function(data, hasMore, url) {
   this.data = data
@@ -17,4 +145,4 @@ List.prototype.toClient = function() {
   }
 }
 
-module.exports = { generateId, List }
+module.exports = { ExpandableSchema, generateId, List }

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -2,4 +2,19 @@ const { customAlphabet, urlAlphabet } = require('nanoid')
 
 const generateId = customAlphabet(urlAlphabet, 10)
 
-module.exports = { generateId }
+const List = function(data, hasMore, url) {
+  this.data = data
+  this.hasMore = hasMore
+  this.url = url
+}
+
+List.prototype.toClient = function() {
+  return {
+    object: 'list',
+    hasMore: this.hasMore,
+    url: this.url,
+    data: this.data
+  }
+}
+
+module.exports = { generateId, List }

--- a/src/models/work.js
+++ b/src/models/work.js
@@ -1,14 +1,11 @@
 const mongoose = require('mongoose')
-const { generateId } = require('./')
-const { Schema } = mongoose
+const { ExpandableSchema } = require('./')
 const { InfoSchema } = require('./info')
 const { MovementSchema } = require('./movement')
 
-const WorkSchema = new Schema({
-  _id: {
-    type: String,
-    default: generateId
-  },
+const MODEL_NAME = 'work'
+
+const WorkSchema = ExpandableSchema('work', {
   composer: {
     type: String,
     required: true,
@@ -23,28 +20,6 @@ const WorkSchema = new Schema({
   info: InfoSchema
 })
 
-WorkSchema.method('toClient', function() {
-  let obj = this.toObject()
-
-  const id = obj._id
-  const object = 'work'
-
-  if (obj.info) obj.info = this.info.toClient()
-  if (obj.movements) obj.movements = this.movements.map(m => m.toClient())
-  if (this.populated('composer')) obj.composer = this.composer.toClient()
-
-  const prune = ({composer, name, movements, catalog, info}) =>
-    ({id, object, composer, name, movements, catalog, info})
-  
-  obj = prune(obj)
-
-  if (this.$locals.deleted) {
-    obj.deleted = true
-  }
-
-  return obj
-})
-
-const Work = mongoose.model('work', WorkSchema)
+const Work = mongoose.model(MODEL_NAME, WorkSchema)
 
 module.exports = {Work, WorkSchema}

--- a/src/models/work.js
+++ b/src/models/work.js
@@ -17,10 +17,9 @@ const WorkSchema = new Schema({
   name: {type: String, required: true},
   movements: [MovementSchema], // TODO: validate that order property on movement is unique within work doc
   catalog: {
-    type: String,
-    ref: 'catalog'
+    name: String,
+    no: String
   },
-  catalogNo: String,
   info: InfoSchema
 })
 
@@ -34,8 +33,8 @@ WorkSchema.method('toClient', function() {
   if (obj.movements) obj.movements = this.movements.map(m => m.toClient())
   if (this.populated('composer')) obj.composer = this.composer.toClient()
 
-  const prune = ({composer, name, movements, catalog, catalogNo, info}) =>
-    ({id, object, composer, name, movements, catalog, catalogNo, info})
+  const prune = ({composer, name, movements, catalog, info}) =>
+    ({id, object, composer, name, movements, catalog, info})
   
   obj = prune(obj)
 

--- a/src/services/composer.js
+++ b/src/services/composer.js
@@ -6,7 +6,7 @@ const ComposerService = {
 
   async findById(id, expand = ['works']) {
     let composer = await Composer.findById(id).exec()
-    composer = await composer.expand(expand)
+    if (composer) composer = await composer.expand(expand)
     
     return composer
   },

--- a/src/services/composer.js
+++ b/src/services/composer.js
@@ -1,28 +1,38 @@
 const { Composer } = require('../models/composer')
 
 const ComposerService = {
-  async findById(id) {
-    const composer = await Composer.findById(id).exec()
+  // TODO: optional populate; adjustable works limit
+  // TODO: sort populated works by some sort of relevance metric
 
+  async findById(id, expand = ['works']) {
+    let composer = await Composer.findById(id).exec()
+    composer = await composer.expand(expand)
+    
     return composer
   },
 
-  async create(obj) {
+  async create(obj, expand = ['works']) {
     // TODO: protect against creating a composer with identical name of another composer
 
-    const composer = new Composer(obj)
-
-    return await composer.save()
-  },
-
-  async update(id, obj) {
-    const composer = await Composer.findByIdAndUpdate(id, {$set: obj}, {new: true}).exec()
+    let composer = new Composer(obj)
+    composer = await composer.save()
+    composer = await composer.expand(expand)
 
     return composer
   },
 
-  async delete(id) {
-    const composer = await Composer.findByIdAndDelete(id).exec()
+  async update(id, obj, expand = ['works']) {
+    let composer = await Composer.findByIdAndUpdate(id, {$set: obj}, {new: true}).exec()
+    composer = await composer.expand(expand)
+
+    return composer
+  },
+
+  async delete(id, expand = ['works']) {
+    // TODO: forbid deleting a composer that has remaning works
+
+    let composer = await Composer.findByIdAndDelete(id).exec()
+    composer = await composer.expand(expand)
 
     if (composer) {
       composer.$locals.deleted = true // mark as deleted for client response

--- a/src/services/composer.js
+++ b/src/services/composer.js
@@ -23,7 +23,13 @@ const ComposerService = {
 
   async delete(id) {
     const composer = await Composer.findByIdAndDelete(id).exec()
-    if (composer) composer.$locals.deleted = true // mark as deleted for client response
+
+    if (composer) {
+      composer.$locals.deleted = true // mark as deleted for client response
+
+      // propagate deleted prop to subdocs
+      if (composer.info) composer.info.$locals.deleted = true
+    }
 
     return composer
   }

--- a/src/services/work.js
+++ b/src/services/work.js
@@ -3,30 +3,34 @@ const { Work } = require('../models/work')
 const WorkService = {
   // TODO: optional population
 
-  async findById(id) {
-    const work = await Work.findById(id).populate('composer').exec()
-
+  async findById(id, expand = ['composer']) {
+    let work = await Work.findById(id).exec()
+    if (work) work = await work.expand(expand)
+    
     return work
   },
 
-  async create(obj) {
+  async create(obj, expand = ['composer']) {
     // TODO: protect against creating a work with identical name of another work
 
     let work = new Work(obj)
     work = await work.save()
-    work = await work.populate('composer').execPopulate()
+    work = await work.expand(expand)
 
     return work
   },
 
-  async update(id, obj) {
-    const work = await Work.findByIdAndUpdate(id, {$set: obj}, {new: true}).populate('composer').exec()
+  async update(id, obj, expand = ['composer']) {
+    let work = await Work.findByIdAndUpdate(id, {$set: obj}, {new: true}).exec()
+    if (work) work = await work.expand(expand)
 
     return work
   },
 
-  async delete(id) {
-    const work = await Work.findByIdAndDelete(id).populate('composer').exec()
+  async delete(id, expand = ['composer']) {
+    let work = await Work.findByIdAndDelete(id).populate('composer').exec()
+    if (work) work = await work.expand(expand)
+
     if (work) {
       work.$locals.deleted = true // mark as deleted for client response
 


### PR DESCRIPTION
Created inheritable ExpandableSchema to reduce repetition of `expand` and `toClient` methods in models.

Added catalog fields to Work and Composer model

Moved request schemas to separate files in `api/schemas`