### PR TITLE
Add "list composers" and "list works" routes

### DIFF
--- a/src/api/middleware/validation.js
+++ b/src/api/middleware/validation.js
@@ -1,4 +1,4 @@
-const ajv = require('../../loaders/ajv')
+const { ajv, ajvCoerce } = require('../../loaders/ajv')
 const { BadRequestError, ValidationError } = require('./errors')
 
 const bodyValidator = schema => {
@@ -14,10 +14,10 @@ const bodyValidator = schema => {
 }
 
 const queryValidator = schema => {
-  const validator = ajv.compile(schema)
+  const validator = ajvCoerce.compile(schema) // ajvCoerce converts values to schema types if possible
 
   return (req, res, next) => {
-    const valid = validator(req.query)
+    const valid = validator(req.query) // mutates req.query with type coercions
 
     if (valid) return next()
 
@@ -27,9 +27,9 @@ const queryValidator = schema => {
 
 // Throws request error corresponding to AJV validator errors
 const throwValidationError = errors => {
-  if (!validator.errors || !validator.errors[0]) return
+  if (!errors || !errors[0]) return
 
-  const err = validator.errors[0]
+  const err = errors[0]
 
   if (err.keyword == 'additionalProperties') {
     const prop = err.params.additionalProperty

--- a/src/api/middleware/validation.js
+++ b/src/api/middleware/validation.js
@@ -1,7 +1,7 @@
 const ajv = require('../../loaders/ajv')
 const { BadRequestError, ValidationError } = require('./errors')
 
-const bodyValidator = (schema) => {
+const bodyValidator = schema => {
   const validator = ajv.compile(schema)
 
   return (req, res, next) => {
@@ -9,31 +9,48 @@ const bodyValidator = (schema) => {
 
     if (valid) return next()
 
-    if (validator.errors && validator.errors[0]) {
-      const err = validator.errors[0]
-
-      if (err.keyword == 'additionalProperties') {
-        const prop = err.params.additionalProperty
-
-        throw new BadRequestError(`Unknown property '${prop}' in body.`, prop)
-      } else if (err.keyword == 'required') {
-        const prop = err.params.missingProperty
-
-        throw new BadRequestError(`Missing required property '${prop}'.`, prop)
-      } else if (err.keyword == 'type') {
-        const type = err.params.type
-
-        // convert json-schema path /prop/nestedProp to prop.nestedProp
-        const path = err.dataPath.slice(1).split('/').join('.') // TODO: test this; especially for arrays
-
-        throw new ValidationError(`Expected '${path}' to be of type '${type}'.`, path)
-      }
-
-      // TODO: add more validation cases
-    }
-
-    throw new ValidationError() // default validation error
+    throwValidationError(validator.errors)
   }
 }
 
-module.exports = { bodyValidator }
+const queryValidator = schema => {
+  const validator = ajv.compile(schema)
+
+  return (req, res, next) => {
+    const valid = validator(req.query)
+
+    if (valid) return next()
+
+    throwValidationError(validator.errors)
+  }
+}
+
+// Throws request error corresponding to AJV validator errors
+const throwValidationError = errors => {
+  if (!validator.errors || !validator.errors[0]) return
+
+  const err = validator.errors[0]
+
+  if (err.keyword == 'additionalProperties') {
+    const prop = err.params.additionalProperty
+
+    throw new BadRequestError(`Unknown property '${prop}' in body.`, prop)
+  } else if (err.keyword == 'required') {
+    const prop = err.params.missingProperty
+
+    throw new BadRequestError(`Missing required property '${prop}'.`, prop)
+  } else if (err.keyword == 'type') {
+    const type = err.params.type
+
+    // convert json-schema path /prop/nestedProp to prop.nestedProp
+    const path = err.dataPath.slice(1).split('/').join('.') // TODO: test this; especially for arrays
+
+    throw new ValidationError(`Expected '${path}' to be of type '${type}'.`, path)
+  }
+
+  // TODO: add more validation cases
+
+  throw new ValidationError() // default validation error
+}
+
+module.exports = { bodyValidator, queryValidator }

--- a/src/api/routes/composer.js
+++ b/src/api/routes/composer.js
@@ -1,11 +1,19 @@
 const route = require('express-promise-router')()
-const { PostSchema, PatchSchema } = require('../schemas/composer')
+const { ListSchema, PostSchema, PatchSchema } = require('../schemas/composer')
 const ComposerService = require('../../services/composer')
 const { NotFoundError } = require('../middleware/errors')
-const { bodyValidator } = require('../middleware/validation')
+const { bodyValidator, queryValidator } = require('../middleware/validation')
 
 module.exports = (router) => {
   router.use('/composer', route)
+
+  route.get('/', queryValidator(ListSchema), async (req, res) => {
+    const {limit, start} = req.query
+
+    const components = await ComposerService.list({limit, skip: start})
+
+    res.sendDocument(components)
+  })
 
   route.get('/:id', async (req, res) => {
     const id = req.params.id

--- a/src/api/routes/work.js
+++ b/src/api/routes/work.js
@@ -1,11 +1,19 @@
 const route = require('express-promise-router')()
-const { PostSchema, PatchSchema } = require('../schemas/work')
+const { ListSchema, PostSchema, PatchSchema } = require('../schemas/work')
 const WorkService = require('../../services/work')
 const { NotFoundError } = require('../middleware/errors')
-const { bodyValidator } = require('../middleware/validation')
+const { bodyValidator, queryValidator } = require('../middleware/validation')
 
 module.exports = (router) => {
   router.use('/work', route)
+
+  route.get('/', queryValidator(ListSchema), async (req, res) => {
+    const {composer, limit, start} = req.query
+
+    const works = await WorkService.list({composer, limit, skip: start})
+
+    res.sendDocument(works)
+  })
 
   route.get('/:id', async (req, res) => {
     const id = req.params.id

--- a/src/api/schemas/composer.js
+++ b/src/api/schemas/composer.js
@@ -29,4 +29,13 @@ const ComposerSchema = req => {
 const PostSchema = ComposerSchema(true)
 const PatchSchema = ComposerSchema(false)
 
-module.exports = { ComposerSchema, PostSchema, PatchSchema }
+// schema for query parameters
+const ListSchema = {
+  type: 'object',
+  properties: {
+    limit: {type: 'integer'}, // TODO: positive
+    start: {type: 'integer'} // TODO: positive
+  }
+}
+
+module.exports = { ComposerSchema, PostSchema, PatchSchema, ListSchema }

--- a/src/api/schemas/work.js
+++ b/src/api/schemas/work.js
@@ -30,4 +30,13 @@ const WorkSchema = req => {
 const PostSchema = WorkSchema(true)
 const PatchSchema = WorkSchema(false)
 
-module.exports = { WorkSchema, PostSchema, PatchSchema }
+const ListSchema = {
+  type: 'object',
+  properties: {
+    composer: {type: 'string'}, // TODO: enforce ID format
+    limit: {type: 'integer'}, // TODO: positive
+    start: {type: 'integer'} // TODO: positive
+  }
+}
+
+module.exports = { WorkSchema, PostSchema, PatchSchema, ListSchema }

--- a/src/loaders/ajv.js
+++ b/src/loaders/ajv.js
@@ -1,4 +1,5 @@
 const Ajv = require('ajv').default
 const ajv = new Ajv()
+const ajvCoerce = new Ajv({coerceTypes: true})
 
-module.exports = ajv
+module.exports = { ajv, ajvCoerce }

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -1,5 +1,5 @@
-const ajv = require('./ajv')
+const { ajv, ajvCoerce } = require('./ajv')
 const mongooseUtil = require('./mongoose')
 const app = require('./express')
 
-module.exports = { ajv, mongooseUtil, app }
+module.exports = { ajv, ajvCoerce, mongooseUtil, app }

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -110,13 +110,11 @@ const addClientFormatter = (name, schema, def, virtuals) => {
     subDocArrays.forEach(prop => {
       if (!this[prop]) return
 
-      const data = this[prop].map(doc => doc.toClient())
-
       if (this.populated(prop)) {
-        const list = new List(data, this.$locals[prop].hasMore, '/') // TODO: use real url
+        const list = new List(this[prop], this.$locals[prop].hasMore, '/') // TODO: use real url
         newObj[prop] = list.toClient()
       } else {
-        newObj[prop] = data
+        newObj[prop] = this[prop].map(doc => doc.toClient())
       }
     })
 
@@ -141,11 +139,13 @@ const List = function(data, hasMore, url) {
 }
 
 List.prototype.toClient = function() {
+  let data = this.data.map(doc => doc.toClient())
+
   return {
     object: 'list',
     hasMore: this.hasMore,
     url: this.url,
-    data: this.data
+    data
   }
 }
 

--- a/src/services/composer.js
+++ b/src/services/composer.js
@@ -5,9 +5,11 @@ const ComposerService = {
   // TODO: sort populated works by some sort of relevance metric
 
   async list({limit, skip} = {}) {
-    const options = {limit: 10, skip: 0}
-    if (limit) options.limit = limit
-    if (skip) options.skip = skip
+    const defaults = {limit: 10, skip: 0}
+    if (!limit) limit = defaults.limit
+    if (!skip) skip = defaults.skip
+
+    const options = {limit, skip}
 
     let composers = await Composer.find({}, null, options).exec()
     let hasMore

--- a/src/services/composer.js
+++ b/src/services/composer.js
@@ -1,8 +1,28 @@
+const { List } = require('../models')
 const { Composer } = require('../models/composer')
 
 const ComposerService = {
-  // TODO: optional populate; adjustable works limit
   // TODO: sort populated works by some sort of relevance metric
+
+  async list({limit, skip} = {}) {
+    const options = {limit: 10, skip: 0}
+    if (limit) options.limit = limit
+    if (skip) options.skip = skip
+
+    let composers = await Composer.find({}, null, options).exec()
+    let hasMore
+    
+    if (composers.length < limit) {
+      hasMore = false
+    } else {
+      const remainingCount = await Composer.estimatedDocumentCount({skip})
+      hasMore = remainingCount > limit
+    }
+
+    const list = new List(composers, hasMore, '/') // TODO: use real url
+
+    return list
+  },
 
   async findById(id, expand = ['works']) {
     let composer = await Composer.findById(id).exec()


### PR DESCRIPTION
Created the following routes:

1. `GET /composer` - Lists all composers with pagination
2. `GET /work` - Lists all works with pagination and composer ID filtering

In doing, the following components were created

- query validation middleware
- list method in works and composers services
- list query schemas