### PR TITLE
#13 Add 'search' parameter to composer 'list' route

### DIFF
--- a/src/api/routes/composer.js
+++ b/src/api/routes/composer.js
@@ -9,11 +9,11 @@ module.exports = (router) => {
   router.use('/composer', route)
 
   route.get('/', queryValidator(ListSchema), async (req, res) => {
-    const {limit, start} = req.query
+    const {search, limit, start} = req.query
 
-    const components = await ComposerService.list({limit, skip: start})
+    const composers = await ComposerService.list({search, limit, skip: start})
 
-    res.sendDocument(components)
+    res.sendDocument(composers)
   })
 
   route.get('/:id', async (req, res) => {

--- a/src/api/schemas/composer.js
+++ b/src/api/schemas/composer.js
@@ -37,6 +37,7 @@ const PatchSchema = ComposerSchema(false)
 const ListSchema = {
   type: 'object',
   properties: {
+    search: {type: 'string'},
     limit: {type: 'integer'}, // TODO: positive
     start: {type: 'integer'} // TODO: positive
   }

--- a/src/models/composer.js
+++ b/src/models/composer.js
@@ -25,6 +25,30 @@ const ComposerSchema = ExpandableSchema(MODEL_NAME, {
   }
 })
 
+// fields to search composer on
+// TODO: research the limit of text index field size. these fields combined could become very large
+const textIndexFields = [
+  'name.title',
+  'name.first',
+  'name.last',
+  'name.middle',
+  'name.suffix',
+  'name.nick',
+  'catalog'
+].concat(InfoSchema.textIndexFields.map(f => `info.${f}`))
+ .concat(TagSchema.textIndexFields.map(f => `tags.${f}`))
+
+// turns fields array ['example'] to {example: 'test'} for mongoose index method
+const textIndexObj = textIndexFields.reduce((obj, field) => Object.assign(obj, {[field]: 'text'}), {})
+
+// create text index for search
+ComposerSchema.index(textIndexObj, {
+  name: 'search',
+  weights: { // TODO: adjust weights to improve search performance
+    'name.last': 2
+  }
+})
+
 const Composer = mongoose.model(MODEL_NAME, ComposerSchema)
 
 module.exports = {Composer, ComposerSchema}

--- a/src/models/info.js
+++ b/src/models/info.js
@@ -27,4 +27,7 @@ InfoSchema.method('toClient', function() {
   return obj
 })
 
+// fields that info should be searched on
+InfoSchema.textIndexFields = ['content']
+
 module.exports = { InfoSchema }

--- a/src/models/tag.js
+++ b/src/models/tag.js
@@ -28,6 +28,9 @@ TagSchema.method('toClient', function() {
   return newObj
 })
 
+// fields that tag should be searched on
+TagSchema.textIndexFields = ['name']
+
 const Tag = mongoose.model(MODEL_NAME, TagSchema)
 
 module.exports = { Tag, TagSchema }


### PR DESCRIPTION
Added composer search functionality to the `GET /composer` route. I did this by creating a  [searchable mongodb text index](https://docs.mongodb.com/manual/core/index-text/) on the composer `name`, `catalog`, `info`, and `tags`.