### PR TITLE
Add work searching

### DIFF
--- a/src/api/routes/work.js
+++ b/src/api/routes/work.js
@@ -9,9 +9,9 @@ module.exports = (router) => {
   router.use('/work', route)
 
   route.get('/', queryValidator(ListSchema), async (req, res) => {
-    const {composer, limit, start} = req.query
+    const {composer, limit, start, search} = req.query
 
-    const works = await WorkService.list({composer, limit, skip: start})
+    const works = await WorkService.list({composer, limit, skip: start, search})
 
     res.sendDocument(works)
   })

--- a/src/models/movement.js
+++ b/src/models/movement.js
@@ -11,7 +11,6 @@ const MovementSchema = new Schema({
   order: {
     type: Number,
     required: true,
-    unique: true,
     validate: {
       validator: Number.isInteger,
       message: '{VALUE} is not an integer value'
@@ -35,5 +34,8 @@ MovementSchema.method('toClient', function() {
 
   return obj
 })
+
+// fields that movement should be searched on
+MovementSchema.textIndexFields = ['name']
 
 module.exports = { MovementSchema }

--- a/src/models/work.js
+++ b/src/models/work.js
@@ -22,6 +22,26 @@ const WorkSchema = ExpandableSchema('work', {
   tags: [TagSchema]
 })
 
+// fields to search composer on
+// TODO: is it possible for a doc to be searchable by an external reference like composer name?
+const textIndexFields = [
+  'name',
+  'catalog'
+].concat(InfoSchema.textIndexFields.map(f => `info.${f}`))
+ .concat(TagSchema.textIndexFields.map(f => `tags.${f}`))
+ .concat(MovementSchema.textIndexFields.map(f => `movements.${f}`))
+
+// turns fields array ['example'] to {example: 'test'} for mongoose index method
+const textIndexObj = textIndexFields.reduce((obj, field) => Object.assign(obj, {[field]: 'text'}), {})
+
+// create text index for search
+WorkSchema.index(textIndexObj, {
+  name: 'search',
+  weights: { // TODO: adjust weights to improve search performance
+    'name': 5
+  }
+})
+
 const Work = mongoose.model(MODEL_NAME, WorkSchema)
 
 module.exports = {Work, WorkSchema}


### PR DESCRIPTION
Closes #12 

Makes works searchable using the `search` parameter in the `list works` route, similar to composer searching.