### PR TITLE
Add performer searching

### DIFF
--- a/src/api/routes/performer.js
+++ b/src/api/routes/performer.js
@@ -9,9 +9,9 @@ module.exports = (router) => {
   router.use('/performer', route)
 
   route.get('/', queryValidator(ListSchema), async (req, res) => {
-    const {limit, start} = req.query
+    const {limit, start, search} = req.query
 
-    const components = await PerformerService.list({limit, skip: start})
+    const components = await PerformerService.list({limit, skip: start, search})
 
     res.sendDocument(components)
   })

--- a/src/models/performer.js
+++ b/src/models/performer.js
@@ -22,6 +22,28 @@ const PerformerSchema = ExpandableSchema(MODEL_NAME, {
   }
 })
 
+// fields to search composer on
+// TODO: research the limit of text index field size. these fields combined could become very large
+const textIndexFields = [
+  'name.title',
+  'name.first',
+  'name.last',
+  'name.middle',
+  'name.suffix',
+  'name.nick'
+].concat(InfoSchema.textIndexFields.map(f => `info.${f}`))
+
+// turns fields array ['example'] to {example: 'test'} for mongoose index method
+const textIndexObj = textIndexFields.reduce((obj, field) => Object.assign(obj, {[field]: 'text'}), {})
+
+// create text index for search
+PerformerSchema.index(textIndexObj, {
+  name: 'search',
+  weights: { // TODO: adjust weights to improve search performance
+    'name.last': 2
+  }
+})
+
 const Performer = mongoose.model(MODEL_NAME, PerformerSchema)
 
 module.exports = {Performer, PerformerSchema}

--- a/src/services/performer.js
+++ b/src/services/performer.js
@@ -4,20 +4,27 @@ const { Performer } = require('../models/performer')
 const PerformerService = {
 
   // TODO: filter by performance
-  async list({limit, skip} = {}) {
+  async list({limit, skip, search} = {}) {
     const defaults = {limit: 10, skip: 0}
     if (!limit) limit = defaults.limit
     if (!skip) skip = defaults.skip
 
+    const filter = {}
+    const proj = {}
     const options = {limit, skip}
 
-    let performers = await Performer.find({}, null, options).exec()
+    if (search && search != '') {
+      filter.$text = {$search: search}
+      proj.score = {$meta: 'textScore'}
+    }
+
+    let performers = await Performer.find(filter, proj, options).exec()
     let hasMore
     
     if (performers.length < limit) {
       hasMore = false
     } else {
-      const remainingCount = await Performer.estimatedDocumentCount({skip})
+      const remainingCount = await Performer.estimatedDocumentCount({skip}) // TODO: count broken for searching
       hasMore = remainingCount > limit
     }
 


### PR DESCRIPTION
Closes #22 

Makes performers searchable using the search parameter in the list performer route, similar to composer or work searching.