### PR TITLE
Add populateTags option for retrieve composers

### DIFF
--- a/src/api/routes/composer.js
+++ b/src/api/routes/composer.js
@@ -1,5 +1,5 @@
 const route = require('express-promise-router')()
-const { ListSchema, PostSchema, PatchSchema } = require('../schemas/composer')
+const { ListSchema, RetrieveSchema, PostSchema, PatchSchema } = require('../schemas/composer')
 const ComposerService = require('../../services/composer')
 const { NotFoundError } = require('../middleware/errors')
 const { bodyValidator, queryValidator } = require('../middleware/validation')
@@ -16,9 +16,11 @@ module.exports = (router) => {
     res.sendDocument(composers)
   })
 
-  route.get('/:id', async (req, res) => {
+  route.get('/:id', queryValidator(RetrieveSchema), async (req, res) => {
+    const { populateTags } = req.query
+
     const id = req.params.id
-    const composer = await ComposerService.findById(id)
+    const composer = await ComposerService.findById(id, { populateTagComposers: populateTags })
 
     if (!composer) throw new NotFoundError(`Composer with id '${id}' does not exist.`)
 

--- a/src/api/schemas/composer.js
+++ b/src/api/schemas/composer.js
@@ -43,4 +43,11 @@ const ListSchema = {
   }
 }
 
-module.exports = { ComposerSchema, PostSchema, PatchSchema, ListSchema }
+const RetrieveSchema = {
+  type: 'object',
+  properties: {
+    populateTags: {type: 'boolean'}
+  }
+}
+
+module.exports = { ComposerSchema, PostSchema, PatchSchema, ListSchema, RetrieveSchema }

--- a/src/models/tag.js
+++ b/src/models/tag.js
@@ -23,6 +23,9 @@ TagSchema.method('toClient', function() {
 
   const newObj = prune(obj)
 
+  // `composers` is sometimes populated by ComposerService
+  if (this.composers) newObj.composers = this.composers.toClient()
+
   if (this.$locals.deleted) newObj.deleted = true
 
   return newObj


### PR DESCRIPTION
Adds `populateTags` option for retrieve composers. When true, it returns all composers that have the same tags as the composer being retrieved.